### PR TITLE
Updated for older TIA Versions, even though compiler uses V20

### DIFF
--- a/Siemens/Openness.cs
+++ b/Siemens/Openness.cs
@@ -1,4 +1,13 @@
-﻿using Siemens.Collaboration.Net;
+﻿
+using Microsoft.Win32;
+using Siemens.Collaboration.Net;
+using Siemens.Engineering;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Principal;
 using System.Threading.Tasks;
 
 namespace TiaMcpServer.Siemens
@@ -9,16 +18,16 @@ namespace TiaMcpServer.Siemens
 
         public static void Initialize(int? tiaMajorVersion = 20)
         {
-            // with nuget packages:
-            // 2.1 nuget package: Siemens.Collaboration.Net.TiaPortal.Openness.Resolver
-            //     & User Environment Variable: TiaPortalLocation=C:\Program Files\Siemens\Automation\Portal V20
-            // 2.2 nuget package: Siemens.Collaboration.Net.TiaPortal.Packages.Openness
-            // 2.3 Api.Global.Openness().Initialize(tiaMajorVersion: 20); // fixed version 20
+            // This initialization ensures compatibility with both future and past TIA Portal Openness NuGet packages.
+            // Specifically, it addresses scenarios related to:
+            // 2.1 Siemens.Collaboration.Net.TiaPortal.Openness.Resolver (requires TiaPortalLocation environment variable)
+            // 2.2 Siemens.Collaboration.Net.TiaPortal.Packages.Openness
+            // 2.3 Direct API initialization: Api.Global.Openness().Initialize(tiaMajorVersion: 20);
 
             TiaMajorVersion = tiaMajorVersion ?? 20; // Default to TIA Portal V20 if not specified
 
-            // Initialize the Openness API with the specified TIA Portal major version
-            Api.Global.Openness().Initialize(tiaMajorVersion: tiaMajorVersion);
+
+            AppDomain.CurrentDomain.AssemblyResolve += MyResolver;
         }
 
         public static async Task<bool> IsUserInGroup()
@@ -32,6 +41,85 @@ namespace TiaMcpServer.Siemens
             {
                 return await Api.Global.Openness().AddUserToGroupAsync();
             }
+        }
+
+
+        private static Assembly MyResolver(object sender, ResolveEventArgs args)
+        {
+            var assemblyName = new AssemblyName(args.Name);
+            if (!assemblyName.Name.StartsWith("Siemens.Engineering"))
+            {
+                return null;
+            }
+
+            var tiaInstallPath = GetTiaPortalInstallPath();
+            if (string.IsNullOrEmpty(tiaInstallPath))
+            {
+                throw new InvalidOperationException($"Could not find TIA Portal installation path for version {TiaMajorVersion} in the registry.");
+            }
+
+            var majorVersionString = TiaMajorVersion.ToString();
+            var searchDirectories = new[] 
+            {
+                Path.Combine(tiaInstallPath, "PublicAPI", $"V{majorVersionString}"),
+                Path.Combine(tiaInstallPath, "Bin", "PublicAPI")
+            };
+
+            var versionsToIgnore = new[] { "V13", "V14", "V15", "V16", "V17", "V18", "V19", "V20" }
+                                    .Where(v => v != $"V{majorVersionString}");
+
+            foreach (var dir in searchDirectories)
+            {
+                var assemblyPath = FindAssemblyRecursive(dir, assemblyName.Name + ".dll", versionsToIgnore);
+                if (assemblyPath != null)
+                {
+                    return Assembly.LoadFrom(assemblyPath);
+                }
+            }
+
+            throw new FileNotFoundException($"Could not find DLL '{assemblyName.Name}' for TIA Portal version {TiaMajorVersion} in the installation directories.");
+        }
+
+        private static string GetTiaPortalInstallPath()
+        {
+            var subKeyName = $@"SOFTWARE\Siemens\Automation\_InstalledSW\TIAP{TiaMajorVersion}\TIA_Opns";
+
+            using (var regBaseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64))
+            using (var tiaOpnsKey = regBaseKey.OpenSubKey(subKeyName))
+            {
+                return tiaOpnsKey?.GetValue("Path")?.ToString();
+            }
+        }
+
+        private static string FindAssemblyRecursive(string directory, string fileName, IEnumerable<string> excludedDirectories)
+        {
+            if (!Directory.Exists(directory))
+            {
+                return null;
+            }
+
+            var filePath = Path.Combine(directory, fileName);
+            if (File.Exists(filePath))
+            {
+                return filePath;
+            }
+
+            foreach (var subDir in Directory.GetDirectories(directory))
+            {
+                var subDirName = new DirectoryInfo(subDir).Name;
+                if (excludedDirectories.Contains(subDirName))
+                {
+                    continue;
+                }
+
+                var result = FindAssemblyRecursive(subDir, fileName, excludedDirectories);
+                if (result != null)
+                {
+                    return result;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Siemens/Portal.cs
+++ b/Siemens/Portal.cs
@@ -1379,9 +1379,9 @@ namespace TiaMcpServer.Siemens
                     sb.AppendLine($"{IndentText(indent + 1)}+- PlcSoftware: {plcSoftware.Name}");
                 }
 
-                if (softwareContainer?.Software is HmiSoftware hmiSoftware)
+                if (Openness.TiaMajorVersion >= 19)
                 {
-                    sb.AppendLine($"{IndentText(indent + 1)}+- HmiSoftware: {hmiSoftware.Name}");
+                    TryGetHmiSoftwareInfo(sb, softwareContainer, indent);
                 }
 
                 if (softwareContainer?.Software is HmiTarget hmiTarget)
@@ -1937,6 +1937,14 @@ namespace TiaMcpServer.Siemens
         }
 
         #endregion
+
+        private void TryGetHmiSoftwareInfo(StringBuilder sb, SoftwareContainer? softwareContainer, int indent)
+        {                  
+            if (softwareContainer?.Software is HmiSoftware hmiSoftware)
+            {
+                sb.AppendLine($"{IndentText(indent + 1)}+- HmiSoftware: {hmiSoftware.Name}");
+            } 
+        }
 
         #endregion
 

--- a/TiaMcpServer.csproj
+++ b/TiaMcpServer.csproj
@@ -10,6 +10,9 @@
     <Compile Remove="Siemens\Engineering.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="TextFile1.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.4.25258.110" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
     <PackageReference Include="Siemens.Collaboration.Net.OperatingSystem.Windows" Version="3.0.1725521661" />
@@ -19,16 +22,6 @@
   <ItemGroup>
     <Reference Include="System.Management">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Management.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Update="C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20\Siemens.Engineering.Hmi.dll">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Update="C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20\Siemens.Engineering.dll">
-      <Private>False</Private>
     </Reference>
   </ItemGroup>
 </Project>

--- a/TiaMcpServer.csproj
+++ b/TiaMcpServer.csproj
@@ -21,14 +21,4 @@
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Management.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Update="C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20\Siemens.Engineering.Hmi.dll">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Update="C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20\Siemens.Engineering.dll">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
 </Project>

--- a/TiaMcpServer.csproj
+++ b/TiaMcpServer.csproj
@@ -10,9 +10,6 @@
     <Compile Remove="Siemens\Engineering.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="TextFile1.txt" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0-preview.4.25258.110" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
     <PackageReference Include="Siemens.Collaboration.Net.OperatingSystem.Windows" Version="3.0.1725521661" />
@@ -22,6 +19,16 @@
   <ItemGroup>
     <Reference Include="System.Management">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Management.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20\Siemens.Engineering.Hmi.dll">
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="C:\Program Files\Siemens\Automation\Portal V20\PublicAPI\V20\Siemens.Engineering.dll">
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #1 

TO DO: need to wrap all incompatible calls with own function calls and wrap it with e.g.:

```
if (Openness.TiaMajorVersion >= 19)
{
    TryGetHmiSoftwareInfo(sb, softwareContainer, indent);
}
```